### PR TITLE
Fix falsy values in insertParamsIntoPath

### DIFF
--- a/libs/ts-rest/core/src/lib/paths.spec.ts
+++ b/libs/ts-rest/core/src/lib/paths.spec.ts
@@ -92,4 +92,16 @@ describe('insertParamsIntoPath', () => {
 
     expect(result).toBe('/1');
   });
+
+  it('should handle falsy param values', () => {
+    const path = '/post/:id';
+
+    const params = {
+      id: 0,
+    } as any;
+
+    const result = insertParamsIntoPath({ path, params });
+
+    expect(result).toBe('/post/0');
+  });
 });

--- a/libs/ts-rest/core/src/lib/paths.ts
+++ b/libs/ts-rest/core/src/lib/paths.ts
@@ -62,7 +62,8 @@ export const insertParamsIntoPath = <T extends string>({
 }) => {
   return path
     .replace(/:([^/]+)/g, (_, p) => {
-      return (params as any)[p] || '';
+      const value = (params as any)[p];
+      return value === undefined ? '' : String(value);
     })
     .replace(/\/\//g, '/');
 };


### PR DESCRIPTION
## Summary
- ensure insertParamsIntoPath keeps falsy values
- test for falsy path parameters

## Testing
- `pnpm nx run ts-rest-core:test` *(fails: unable to fetch pnpm)*